### PR TITLE
feat: add support for reading feeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group :development, :test do
   gem "rake", "~> 13.0"
   gem "standard", "~> 1.3"
   gem "yard", "~> 0.9"
-  gem "redcarpet", "~> 3.6"  
+  gem "redcarpet", "~> 3.6"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tightknit (0.1.0)
+    tightknit (0.1.2)
       faraday (~> 2.7)
       json (~> 2.6)
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,40 @@ event = client.calendar_events.get('event_id')
 formatted_event = client.calendar_events.format_data(event[:data])
 ```
 
+### Feeds
+
+#### List Feeds
+
+```ruby
+# Get feeds with default pagination (page 0, per_page 10)
+feeds = client.feeds.list
+
+# With custom pagination
+feeds = client.feeds.list(
+  page: 1,
+  per_page: 20
+)
+```
+
+#### Get a Specific Feed
+
+```ruby
+feed = client.feeds.get('feed_id')
+```
+
+#### Get Posts from a Feed
+
+```ruby
+# Get posts with default pagination (page 0, per_page 10)
+posts = client.feeds.posts('feed_id')
+
+# With custom pagination
+posts = client.feeds.posts('feed_id', 
+  page: 1,
+  per_page: 20
+)
+```
+
 ## Documentation
 
 The gem includes comprehensive YARD documentation. To generate the documentation, first ensure you have the required dependencies:

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ begin
     t.options = ["--output-dir", "doc/yard"]
     t.stats_options = ["--list-undoc"]
   end
-  
+
   desc "Generate YARD documentation and open in browser"
   task :yard_open do
     Rake::Task["yard"].invoke

--- a/lib/tightknit.rb
+++ b/lib/tightknit.rb
@@ -16,7 +16,7 @@ require_relative "tightknit/utils/html_formatter"
 module Tightknit
   # Error class for Tightknit-specific exceptions
   class Error < StandardError; end
-  
+
   # Base URL for the Tightknit API
   BASE_URL = "https://api.tightknit.dev/admin/v0/"
 end

--- a/lib/tightknit.rb
+++ b/lib/tightknit.rb
@@ -3,6 +3,7 @@
 require_relative "tightknit/version"
 require_relative "tightknit/client"
 require_relative "tightknit/resources/calendar_events"
+require_relative "tightknit/resources/feeds"
 require_relative "tightknit/utils/html_formatter"
 
 # The Tightknit module is the main namespace for the Tightknit API client.

--- a/lib/tightknit/client.rb
+++ b/lib/tightknit/client.rb
@@ -37,6 +37,13 @@ module Tightknit
       @calendar_events ||= Resources::CalendarEvents.new(self)
     end
     
+    # Access the feeds resource
+    #
+    # @return [Tightknit::Resources::Feeds] The feeds resource
+    def feeds
+      @feeds ||= Resources::Feeds.new(self)
+    end
+    
     # Make a GET request to the API
     #
     # @param path [String] The path to request

--- a/lib/tightknit/client.rb
+++ b/lib/tightknit/client.rb
@@ -9,41 +9,41 @@ module Tightknit
   #
   # @example Creating a client
   #   client = Tightknit::Client.new(api_key: "your_api_key")
-  #   
+  #
   class Client
     # @return [Faraday::Connection] The Faraday connection object used for HTTP requests
     attr_reader :conn
-    
+
     # Initialize a new Tightknit API client
     #
     # @param api_key [String] The API key to use for authentication
     # @raise [Tightknit::Error] If no API key is provided
     def initialize(api_key:)
       @api_key = api_key
-      
+
       raise Error, "API key is required" unless @api_key
-      
+
       @conn = Faraday.new(url: BASE_URL) do |faraday|
         faraday.headers["Authorization"] = "Bearer #{@api_key}"
         faraday.headers["Content-Type"] = "application/json"
         faraday.adapter Faraday.default_adapter
       end
     end
-    
+
     # Access the calendar events resource
     #
     # @return [Tightknit::Resources::CalendarEvents] The calendar events resource
     def calendar_events
       @calendar_events ||= Resources::CalendarEvents.new(self)
     end
-    
+
     # Access the feeds resource
     #
     # @return [Tightknit::Resources::Feeds] The feeds resource
     def feeds
       @feeds ||= Resources::Feeds.new(self)
     end
-    
+
     # Make a GET request to the API
     #
     # @param path [String] The path to request
@@ -56,9 +56,9 @@ module Tightknit
     rescue Faraday::Error => e
       handle_error(e)
     end
-    
+
     private
-    
+
     # Handle the API response
     #
     # @param response [Faraday::Response] The Faraday response object
@@ -75,11 +75,11 @@ module Tightknit
         rescue JSON::ParserError
           response.body || "Unknown error"
         end
-        
+
         raise Error, "API Error (#{response.status}): #{error_message}"
       end
     end
-    
+
     # Handle Faraday errors
     #
     # @param error [Faraday::Error] The Faraday error
@@ -88,4 +88,4 @@ module Tightknit
       raise Error, "Network Error: #{error.message}"
     end
   end
-end 
+end

--- a/lib/tightknit/resources/calendar_events.rb
+++ b/lib/tightknit/resources/calendar_events.rb
@@ -22,7 +22,7 @@ module Tightknit
       def initialize(client)
         @client = client
       end
-      
+
       # Get a list of calendar events
       #
       # @param options [Hash] Options for filtering events
@@ -35,20 +35,20 @@ module Tightknit
         page = options[:page] || 0
         per_page = options[:per_page] || 10
         time_filter = options[:time_filter]
-        status = options[:status] || 'published'
-        
+        status = options[:status] || "published"
+
         params = {
           page: page,
           per_page: per_page,
           status: status
         }
-        
+
         # Only add time_filter to params if it's specified
         params[:time_filter] = time_filter if time_filter
-        
-        @client.get('calendar_events', params)
+
+        @client.get("calendar_events", params)
       end
-      
+
       # Get both past and upcoming events
       #
       # @param options [Hash] Options for filtering events
@@ -59,26 +59,26 @@ module Tightknit
       def all(options = {})
         # Get upcoming events
         upcoming_options = options.dup
-        upcoming_options[:time_filter] = 'upcoming'
+        upcoming_options[:time_filter] = "upcoming"
         upcoming_response = list(upcoming_options)
-        
+
         # Get past events
         past_options = options.dup
-        past_options[:time_filter] = 'past'
+        past_options[:time_filter] = "past"
         past_response = list(past_options)
-        
+
         # Combine the results
         if upcoming_response[:success] && past_response[:success]
           combined_records = []
-          
+
           if upcoming_response[:data] && upcoming_response[:data][:records]
             combined_records += upcoming_response[:data][:records]
           end
-          
+
           if past_response[:data] && past_response[:data][:records]
             combined_records += past_response[:data][:records]
           end
-          
+
           # Create a combined response with the same structure
           {
             success: true,
@@ -92,7 +92,7 @@ module Tightknit
           upcoming_response[:success] ? upcoming_response : past_response
         end
       end
-      
+
       # Get a specific calendar event
       #
       # @param event_id [String] The ID of the event to retrieve
@@ -101,7 +101,7 @@ module Tightknit
       def get(event_id)
         @client.get("calendar_events/#{event_id}")
       end
-      
+
       # Format event data for the API
       #
       # @param event_data [Hash] The raw event data
@@ -110,29 +110,29 @@ module Tightknit
       def format_data(event_data)
         # Create a new hash to avoid modifying the original
         formatted = event_data.dup
-        
+
         # Format description if it's a string
         if formatted[:description].is_a?(String)
-          formatted[:description] = { text: formatted[:description] }
+          formatted[:description] = {text: formatted[:description]}
         end
-        
+
         # Format recap if it's a string
         if formatted[:recap].is_a?(String)
-          formatted[:recap] = { text: formatted[:recap] }
+          formatted[:recap] = {text: formatted[:recap]}
         end
-        
+
         # Format hosts if it's an array of IDs
         if formatted[:hosts].is_a?(Array)
-          formatted[:hosts] = { slack_user_ids: formatted[:hosts] }
+          formatted[:hosts] = {slack_user_ids: formatted[:hosts]}
         end
-        
+
         # Format speakers if it's an array of IDs
         if formatted[:speakers].is_a?(Array)
-          formatted[:speakers] = { slack_user_ids: formatted[:speakers] }
+          formatted[:speakers] = {slack_user_ids: formatted[:speakers]}
         end
-        
+
         formatted
-      end      
+      end
     end
   end
-end 
+end

--- a/lib/tightknit/resources/feeds.rb
+++ b/lib/tightknit/resources/feeds.rb
@@ -25,7 +25,7 @@ module Tightknit
       def initialize(client)
         @client = client
       end
-      
+
       # Get a list of feeds in the community
       #
       # @param options [Hash] Options for pagination
@@ -35,15 +35,15 @@ module Tightknit
       def list(options = {})
         page = options[:page] || 0
         per_page = options[:per_page] || 10
-        
+
         params = {
           page: page,
           per_page: per_page
         }
-        
-        @client.get('feeds', params)
+
+        @client.get("feeds", params)
       end
-      
+
       # Get a specific feed
       #
       # @param feed_id [String] The ID of the feed to retrieve
@@ -52,7 +52,7 @@ module Tightknit
       def get(feed_id)
         @client.get("feeds/#{feed_id}")
       end
-      
+
       # Get posts from a specific feed
       #
       # @param feed_id [String] The ID of the feed to retrieve posts from
@@ -64,14 +64,14 @@ module Tightknit
       def posts(feed_id, options = {})
         page = options[:page] || 0
         per_page = options[:per_page] || 10
-        
+
         params = {
           page: page,
           per_page: per_page
         }
-        
+
         @client.get("feeds/#{feed_id}/posts", params)
       end
     end
   end
-end 
+end

--- a/lib/tightknit/resources/feeds.rb
+++ b/lib/tightknit/resources/feeds.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Tightknit
+  # The Resources module contains classes for interacting with different API resources.
+  module Resources
+    # The Feeds class provides methods for interacting with the feeds API.
+    # It allows listing feeds and retrieving posts from feeds.
+    #
+    # @example List feeds
+    #   client = Tightknit.client
+    #   feeds = client.feeds.list
+    #
+    # @example Get a specific feed
+    #   client = Tightknit.client
+    #   feed = client.feeds.get("feed_id")
+    #
+    # @example Get posts from a feed
+    #   client = Tightknit.client
+    #   posts = client.feeds.posts("feed_id")
+    #
+    class Feeds
+      # Initialize a new Feeds resource
+      #
+      # @param client [Tightknit::Client] The client to use for API requests
+      def initialize(client)
+        @client = client
+      end
+      
+      # Get a list of feeds in the community
+      #
+      # @param options [Hash] Options for pagination
+      # @option options [Integer] :page (0) Page number
+      # @option options [Integer] :per_page (10) Number of records per page
+      # @return [Hash] Response containing feeds data
+      def list(options = {})
+        page = options[:page] || 0
+        per_page = options[:per_page] || 10
+        
+        params = {
+          page: page,
+          per_page: per_page
+        }
+        
+        @client.get('feeds', params)
+      end
+      
+      # Get a specific feed
+      #
+      # @param feed_id [String] The ID of the feed to retrieve
+      # @return [Hash] Response containing feed data
+      # @raise [Tightknit::Error] If the feed is not found or another error occurs
+      def get(feed_id)
+        @client.get("feeds/#{feed_id}")
+      end
+      
+      # Get posts from a specific feed
+      #
+      # @param feed_id [String] The ID of the feed to retrieve posts from
+      # @param options [Hash] Options for pagination
+      # @option options [Integer] :page (0) Page number
+      # @option options [Integer] :per_page (10) Number of records per page
+      # @return [Hash] Response containing posts data
+      # @raise [Tightknit::Error] If the feed is not found or another error occurs
+      def posts(feed_id, options = {})
+        page = options[:page] || 0
+        per_page = options[:per_page] || 10
+        
+        params = {
+          page: page,
+          per_page: per_page
+        }
+        
+        @client.get("feeds/#{feed_id}/posts", params)
+      end
+    end
+  end
+end 

--- a/lib/tightknit/utils/html_formatter.rb
+++ b/lib/tightknit/utils/html_formatter.rb
@@ -23,7 +23,7 @@ module Tightknit
     #       ]
     #     }
     #   ]
-    #   
+    #
     #   html = Tightknit::Utils::HtmlFormatter.slack_blocks_to_html(blocks)
     #   # => "<p class='mb-4'>Hello, world!</p>"
     #
@@ -38,12 +38,12 @@ module Tightknit
         # @return [String] HTML representation of the Slack blocks
         def slack_blocks_to_html(blocks)
           return "" unless blocks.is_a?(Array)
-          
+
           html = ""
-          
+
           blocks.each do |block|
             next unless block.is_a?(Hash) && block[:type] == "rich_text" && block[:elements].is_a?(Array)
-            
+
             block[:elements].each do |element|
               if element[:type] == "rich_text_section" && element[:elements].is_a?(Array)
                 # Add a paragraph with margin for spacing
@@ -86,12 +86,12 @@ module Tightknit
               end
             end
           end
-          
+
           html
         end
-        
+
         private
-        
+
         # Process a text element from Slack blocks
         #
         # This method takes a text element from Slack blocks and converts it to HTML.
@@ -101,10 +101,10 @@ module Tightknit
         # @return [String] HTML representation of the text element
         def process_text_element(element)
           return "" unless element.is_a?(Hash)
-          
+
           if element[:type] == "text"
             text = element[:text].to_s
-            
+
             if element[:style]
               if element[:style][:bold]
                 return "<strong>#{text}</strong>"
@@ -116,15 +116,15 @@ module Tightknit
                 return "<code>#{text}</code>"
               end
             end
-            
+
             return text
           elsif element[:type] == "link"
             return "<a href='#{element[:url]}' target='_blank' class='text-primary hover:underline'>#{element[:text]}</a>"
           end
-          
+
           ""
         end
       end
     end
   end
-end 
+end

--- a/lib/tightknit/utils/html_formatter.rb
+++ b/lib/tightknit/utils/html_formatter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Tightknit
+  # The Utils module contains utility classes for various helper functions.
   module Utils
     # The HtmlFormatter class provides utilities for converting Slack blocks to HTML.
     # This is useful for displaying event descriptions that are stored in Slack block format.

--- a/lib/tightknit/version.rb
+++ b/lib/tightknit/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Tightknit
-  VERSION = "0.1.1"
+  # Current version of the Tightknit gem
+  VERSION = "0.1.2"
 end

--- a/test/calendar_events_test.rb
+++ b/test/calendar_events_test.rb
@@ -8,39 +8,39 @@ require "time"
 class CalendarEventsTest < Minitest::Test
   def setup
     skip "Skipping API integration tests in CI" if ENV["CI"]
-    
+
     api_key = ENV["TIGHTKNIT_API_KEY"] || "test_api_key"
     @client = Tightknit::Client.new(api_key: api_key)
   end
-  
+
   def test_list_events_with_vcr
     VCR.use_cassette("calendar_events_list") do
       result = @client.calendar_events.list
-      
+
       assert result[:success]
       assert result[:data][:records].is_a?(Array)
     end
   end
-  
+
   def test_list_events_with_time_filter_vcr
     VCR.use_cassette("calendar_events_list_upcoming") do
       # Call the API with time_filter
       result = @client.calendar_events.list(time_filter: "upcoming")
-      
+
       # Verify the result
       assert result[:success]
       assert result[:data][:records].is_a?(Array)
     end
   end
-  
-  def test_get_event_vcr   
+
+  def test_get_event_vcr
     VCR.use_cassette("calendar_events_get") do
       # Call the API to get a specific event
       result = @client.calendar_events.get(ENV["TEST_EVENT_ID"])
-      
+
       # Verify the result
       assert result[:success]
       assert_equal ENV["TEST_EVENT_ID"], result[:data][:id]
     end
   end
-end 
+end

--- a/test/calendar_events_test.rb
+++ b/test/calendar_events_test.rb
@@ -7,6 +7,8 @@ require "time"
 
 class CalendarEventsTest < Minitest::Test
   def setup
+    skip "Skipping API integration tests in CI" if ENV["CI"]
+    
     api_key = ENV["TIGHTKNIT_API_KEY"] || "test_api_key"
     @client = Tightknit::Client.new(api_key: api_key)
   end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -9,61 +9,61 @@ class ClientTest < Minitest::Test
     client = Tightknit::Client.new(api_key: "test_api_key")
     assert_instance_of Tightknit::Client, client
   end
-  
+
   def test_client_initialization_without_api_key
     assert_raises(Tightknit::Error) do
       Tightknit::Client.new(api_key: nil)
     end
-    
+
     assert_raises(ArgumentError) do
       Tightknit::Client.new
     end
   end
-  
+
   def test_client_resources
     client = Tightknit::Client.new(api_key: "test_api_key")
-    
+
     assert_instance_of Tightknit::Resources::CalendarEvents, client.calendar_events
-    
+
     assert_same client.calendar_events, client.calendar_events
   end
-  
+
   def test_client_get_method
     client = Tightknit::Client.new(api_key: "test_api_key")
     conn = mock("Faraday::Connection")
     client.instance_variable_set(:@conn, conn)
-    
+
     # Mock response
     mock_response = mock("Faraday::Response")
     mock_response.stubs(:status).returns(200)
     mock_response.stubs(:body).returns({success: true, data: {id: 1}}.to_json)
-    
+
     # Test GET
     conn.expects(:get).with("test_path", {param: "value"}).returns(mock_response)
     result = client.get("test_path", {param: "value"})
     assert result[:success]
   end
-  
+
   def test_error_handling
     client = Tightknit::Client.new(api_key: "test_api_key")
     conn = mock("Faraday::Connection")
     client.instance_variable_set(:@conn, conn)
-    
+
     # Mock error response
     mock_response = mock("Faraday::Response")
     mock_response.stubs(:status).returns(404)
     mock_response.stubs(:body).returns({error: "Not found"}.to_json)
-    
+
     # Test error handling
     conn.expects(:get).with("test_path", {}).returns(mock_response)
     assert_raises(Tightknit::Error) do
       client.get("test_path")
     end
-    
+
     # Test network error handling
     conn.expects(:get).with("test_path", {}).raises(Faraday::ConnectionFailed.new("Connection failed"))
     assert_raises(Tightknit::Error) do
       client.get("test_path")
     end
   end
-end 
+end

--- a/test/feeds_test.rb
+++ b/test/feeds_test.rb
@@ -7,39 +7,39 @@ require "mocha/minitest"
 class FeedsTest < Minitest::Test
   def setup
     skip "Skipping API integration tests in CI" if ENV["CI"]
-    
+
     api_key = ENV["TIGHTKNIT_API_KEY"] || "test_api_key"
     @client = Tightknit::Client.new(api_key: api_key)
   end
-  
+
   def test_list_feeds_with_vcr
     VCR.use_cassette("feeds_list") do
       result = @client.feeds.list
-      
+
       assert result[:success]
       assert result[:data][:records].is_a?(Array)
     end
   end
-  
-  def test_get_feed_vcr   
+
+  def test_get_feed_vcr
     VCR.use_cassette("feeds_get") do
       # Call the API to get a specific feed
       result = @client.feeds.get(ENV["TEST_FEED_ID"])
-      
+
       # Verify the result
       assert result[:success]
       assert_equal ENV["TEST_FEED_ID"], result[:data][:id]
     end
   end
-  
-  def test_get_posts_vcr   
+
+  def test_get_posts_vcr
     VCR.use_cassette("feeds_posts") do
       # Call the API to get posts from a feed
       result = @client.feeds.posts(ENV["TEST_FEED_ID"])
-      
+
       # Verify the result
       assert result[:success]
       assert result[:data][:records].is_a?(Array)
     end
   end
-end 
+end

--- a/test/feeds_test.rb
+++ b/test/feeds_test.rb
@@ -6,6 +6,8 @@ require "mocha/minitest"
 
 class FeedsTest < Minitest::Test
   def setup
+    skip "Skipping API integration tests in CI" if ENV["CI"]
+    
     api_key = ENV["TIGHTKNIT_API_KEY"] || "test_api_key"
     @client = Tightknit::Client.new(api_key: api_key)
   end

--- a/test/feeds_test.rb
+++ b/test/feeds_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "dotenv/load"
+require "mocha/minitest"
+
+class FeedsTest < Minitest::Test
+  def setup
+    api_key = ENV["TIGHTKNIT_API_KEY"] || "test_api_key"
+    @client = Tightknit::Client.new(api_key: api_key)
+  end
+  
+  def test_list_feeds_with_vcr
+    VCR.use_cassette("feeds_list") do
+      result = @client.feeds.list
+      
+      assert result[:success]
+      assert result[:data][:records].is_a?(Array)
+    end
+  end
+  
+  def test_get_feed_vcr   
+    VCR.use_cassette("feeds_get") do
+      # Call the API to get a specific feed
+      result = @client.feeds.get(ENV["TEST_FEED_ID"])
+      
+      # Verify the result
+      assert result[:success]
+      assert_equal ENV["TEST_FEED_ID"], result[:data][:id]
+    end
+  end
+  
+  def test_get_posts_vcr   
+    VCR.use_cassette("feeds_posts") do
+      # Call the API to get posts from a feed
+      result = @client.feeds.posts(ENV["TEST_FEED_ID"])
+      
+      # Verify the result
+      assert result[:success]
+      assert result[:data][:records].is_a?(Array)
+    end
+  end
+end 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ require "webmock/minitest"
 VCR.configure do |config|
   config.cassette_library_dir = "test/vcr_cassettes"
   config.hook_into :webmock
-  
+
   # Filter out sensitive information like API keys
   config.filter_sensitive_data("<API_KEY>") do |interaction|
     auth_header = interaction.request.headers["Authorization"]&.first
@@ -21,13 +21,13 @@ VCR.configure do |config|
       match[1] if match
     end
   end
-  
+
   # Allow localhost for CI/CD if needed
   config.ignore_localhost = true
-  
+
   # Configure VCR to ignore certain hosts if needed
   # config.ignore_hosts 'example.com', 'localhost', '127.0.0.1'
-  
+
   # Configure default cassette options
   config.default_cassette_options = {
     record: :once,

--- a/test/tightknit_test.rb
+++ b/test/tightknit_test.rb
@@ -6,24 +6,24 @@ class TightknitTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Tightknit::VERSION
   end
-  
+
   def test_base_url_constant
     assert_equal "https://api.tightknit.dev/admin/v0/", Tightknit::BASE_URL
   end
-  
+
   def test_client_initialization
     client = Tightknit::Client.new(api_key: "test_api_key")
     assert_instance_of Tightknit::Client, client
     assert_equal "test_api_key", client.instance_variable_get(:@api_key)
   end
-  
+
   def test_client_initialization_without_api_key
     assert_raises(Tightknit::Error) do
       Tightknit::Client.new(api_key: nil)
     end
-    
+
     assert_raises(ArgumentError) do
       Tightknit::Client.new
     end
   end
-end 
+end

--- a/test/vcr_cassettes/feeds_get.yml
+++ b/test/vcr_cassettes/feeds_get.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.tightknit.dev/admin/v0/feeds/b7a0df7e-e867-4847-8577-3bed1774ac7c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <API_KEY>
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 May 2025 19:24:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cf-Placement:
+      - local-BOS
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 93fcc73ae9c73b87-BOS
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"data":{"id":"b7a0df7e-e867-4847-8577-3bed1774ac7c","label":"Announcements","slug":"announcements","is_unlisted":false,"banner_file_id":null,"emoji_icon":null,"list_view_display_format":"snippet","post_detail_display_format":"discussion","banner_file_url":null,"show_in_navigation_menu":true,"slack_channel_id":"C08FTB08V5M","slack_channel_num_members":4,"slack_channel_purpose_slack_blocks":[{"text":{"text":"Share
+        announcements and updates about company news.","type":"mrkdwn"},"type":"section"}],"slack_channel_purpose_slack_blocks_references":{"mentioned_slack_users":[],"mentioned_slack_channels":[],"custom_emojis":[],"urls":[]},"slack_channel_topic_slack_blocks":[{"text":{"text":"The
+        latest from LokBros Studio!","type":"mrkdwn"},"type":"section"}],"slack_channel_topic_slack_blocks_references":{"mentioned_slack_users":[],"mentioned_slack_channels":[],"custom_emojis":[],"urls":[]}}}'
+  recorded_at: Wed, 14 May 2025 19:24:52 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/feeds_list.yml
+++ b/test/vcr_cassettes/feeds_list.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.tightknit.dev/admin/v0/feeds?page=0&per_page=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <API_KEY>
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 May 2025 19:24:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cf-Placement:
+      - local-BOS
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 93fcc7320a009057-BOS
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"data":{"page":0,"per_page":10,"count":1,"total_records":1,"total_pages":1,"has_next":false,"records":[{"id":"b7a0df7e-e867-4847-8577-3bed1774ac7c","label":"Announcements","slug":"announcements","is_unlisted":false,"banner_file_id":null,"emoji_icon":null,"list_view_display_format":"snippet","post_detail_display_format":"discussion","banner_file_url":null,"show_in_navigation_menu":true,"slack_channel_id":"C08FTB08V5M","slack_channel_num_members":4,"slack_channel_purpose_slack_blocks":[{"text":{"text":"Share
+        announcements and updates about company news.","type":"mrkdwn"},"type":"section"}],"slack_channel_purpose_slack_blocks_references":{"mentioned_slack_users":[],"mentioned_slack_channels":[],"custom_emojis":[],"urls":[]},"slack_channel_topic_slack_blocks":[{"text":{"text":"The
+        latest from LokBros Studio!","type":"mrkdwn"},"type":"section"}],"slack_channel_topic_slack_blocks_references":{"mentioned_slack_users":[],"mentioned_slack_channels":[],"custom_emojis":[],"urls":[]}}]}}'
+  recorded_at: Wed, 14 May 2025 19:24:52 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/feeds_posts.yml
+++ b/test/vcr_cassettes/feeds_posts.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.tightknit.dev/admin/v0/feeds/b7a0df7e-e867-4847-8577-3bed1774ac7c/posts?page=0&per_page=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <API_KEY>
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 May 2025 19:24:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cf-Placement:
+      - local-BOS
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 93fcc7266dfc8fc6-BOS
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"data":{"page":0,"per_page":10,"count":1,"total_records":1,"total_pages":1,"has_next":false,"records":[{"id":"u580h2qjuc8x","created_at":"2025-05-14T19:16:38.630803+00:00","title":"LokBros
+        Studio Praises Tightknit for Building Online Communities","slug":"lokbros-studio-praises-tightknit-for-building-onli","feed_id":"b7a0df7e-e867-4847-8577-3bed1774ac7c","author_profile_id":"cfa233f7-a0ac-431e-8f94-27a286f2ac32","read_time_minutes":1,"file_attachments_count":0,"reactions_count":0,"comments_count":0,"slack_message":{"id":"48be2df9-5c99-4668-89f1-4837a1abd06c","message_ts":1747250195.525399,"blocks":[{"type":"rich_text","block_id":"UZA6H","elements":[{"type":"rich_text_section","elements":[{"text":"Hello
+        everyone! LokBros Studio is a huge fan of Tightknit. We think it''s the best
+        way to make an online community. The power of Slack + the superpowers of online
+        community builders. ","type":"text"},{"name":"yarn","type":"emoji","unicode":"1f9f6"},{"text":"
+        ","type":"text"},{"name":"heart","type":"emoji","unicode":"2764-fe0f"},{"text":"
+        ","type":"text"},{"name":"zap","type":"emoji","unicode":"26a1"}]}]}],"markdown":"Hello
+        everyone! LokBros Studio is a huge fan of Tightknit. We think it''s the best
+        way to make an online community. The power of Slack + the superpowers of online
+        community builders. :yarn: :heart: :zap:","permalink":"https://lokbros-studio-hub.slack.com/archives/C08FTB08V5M/p1747250195525399","parent_slack_message_id":null},"author":{"profile_id":"cfa233f7-a0ac-431e-8f94-27a286f2ac32","created_at":"2025-03-07T21:27:39.926104+00:00","preferred_name":"Saalik","slack_user_id":"U08FTAZTVJT","slack_is_admin":true,"slack_is_bot":false,"slack_image_72":"https://avatars.slack-edge.com/2025-03-05/8553243603539_a17208ec0a2fe09127eb_72.jpg","slack_image_original":"https://avatars.slack-edge.com/2025-03-05/8553243603539_a17208ec0a2fe09127eb_original.jpg"},"feed":{"id":"b7a0df7e-e867-4847-8577-3bed1774ac7c","label":"Announcements","slug":"announcements"},"references":{"mentioned_slack_users":[],"mentioned_slack_channels":[],"custom_emojis":[],"urls":[]}}]}}'
+  recorded_at: Wed, 14 May 2025 19:24:50 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
This adds support for GET requests for Tightknit feeds:

- Get a list of all feeds
- Get a single feed
- Get posts from a feed, paginated

Bumps the version to 0.1.2

It also updates how testing is done in the CI and a slew of linting fixes.